### PR TITLE
#163127203 Ch integrate coveralls 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 install:
     - pip install -r requirements.txt
+    - pip install coveralls
 
 script:
     - pytest --cov=./app
@@ -13,3 +14,6 @@ script:
 branches:
     only:
       - develop
+
+after_success:
+    - coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Questioner
 [![Build Status](https://travis-ci.org/wathigo/Questioner.svg?branch=develop)](https://travis-ci.org/wathigo/Questioner)
+[![Coverage Status](https://coveralls.io/repos/github/wathigo/Questioner/badge.svg?branch=develop)](https://coveralls.io/github/wathigo/Questioner?branch=develop)
 
 This is a platform where users can post questions that they want addressed during a meetup. Those who want to  attend can then upvote or downvote the question. Users can also comment to a question.
 Here are the concepts that are necessary for completion of this project:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aniso8601==4.1.0
 atomicwrites==1.2.1
 attrs==18.2.0
 Click==7.0
+coverage==4.5.2
 Flask==1.0.2
 Flask-RESTful==0.3.7
 gunicorn==19.9.0
@@ -9,6 +10,7 @@ itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.0
 more-itertools==5.0.0
+pkg-resources==0.0.0
 pluggy==0.8.1
 py==1.7.0
 pytest==4.1.0


### PR DESCRIPTION
### What does this PR do?
Integrates the repository with coveralls to display test coverage.

### Description of the task to be completed.
Integration with Travis coverall badge to display test coverage.

### How can this be manually tested.
Open the browser.
Go to the URL https://github.com/wathigo/Questioner.
Check the README file preview.

### Relevant PT stories
#163127203

### Screenshots
![screenshot from 2019-01-10 15-11-34](https://user-images.githubusercontent.com/44072711/50994356-104e9900-14ea-11e9-8994-3a24a014e564.png)
