### PR TITLE
#163508716 Fix delete meetup 

### DIFF
--- a/app/tests/v2/test_meetups.py
+++ b/app/tests/v2/test_meetups.py
@@ -51,3 +51,11 @@ class TestMeetups(BaseTests):
         headers={"Content-Type" : "application/json",
                  "Authorization" : "Bearer " + token})
         self.assertEqual(response.status_code, 200)
+
+    def test_04_delete(self):
+        """ Test for delete meetup endpont"""
+        response, token = self.create_record()
+        response = self.client.delete('/api/v2/meetups/1', \
+        headers={"Content-Type" : "application/json",
+                 "Authorization" : "Bearer " + token})
+        self.assertEqual(response.status_code, 200)

--- a/app/utils/database/db_config.py
+++ b/app/utils/database/db_config.py
@@ -14,7 +14,7 @@ def table_queries():
     registeredon timestamp,
     email char varying(50) NOT NULL,
     password char varying(30) NOT NULL
-    )"""
+    );"""
 
     """ Create meetup record creation table"""
     meetups = """CREATE TABLE IF NOT EXISTS meetups
@@ -24,8 +24,7 @@ def table_queries():
     description char varying(100) NOT NULL,
     location char varying(30) NOT NULL,
     happeningon char(30) NOT NULL,
-    userid int NOT NULL,
-    FOREIGN KEY (userid) REFERENCES user_table(userid),
+    userid int REFERENCES user_table(userid),
     createdon timestamp
     );"""
 
@@ -36,11 +35,9 @@ def table_queries():
     title char varying(30) NOT NULL,
     question char varying(80) NOT NULL,
     votes integer NOT NULL DEFAULT 0,
-    userid integer NOT NULL,
-    meetupid integer NOT NULL,
-    askedon timestamp,
-    FOREIGN KEY (userid) REFERENCES user_table(userid),
-    FOREIGN KEY (meetupid) REFERENCES meetups(meetupid) ON DELETE CASCADE
+    userid integer REFERENCES user_table(userid),
+    meetupid integer REFERENCES meetups(meetupid) ON DELETE CASCADE,
+    askedon timestamp
     );"""
 
     """ Create reserve record creation table"""
@@ -48,23 +45,18 @@ def table_queries():
     (
     id SERIAL PRIMARY KEY NOT NULL,
     response char(20) NOT NULL,
-    userid int NOT NULL,
-    meetupid integer NOT NULL,
-    reservedon timestamp,
-    FOREIGN KEY (userid) REFERENCES user_table(userid),
-    FOREIGN KEY (meetupid) REFERENCES meetups(meetupid) ON DELETE CASCADE
-    );"""
+    userid int REFERENCES user_table(userid),
+    meetupid integer REFERENCES meetups(meetupid) ON DELETE CASCADE,
+    reservedon timestamp);"""
 
     comment = """CREATE TABLE IF NOT EXISTS comments
     (
-    userid int NOT NULL,
-    questionid int NOT NULL,
+    userid int REFERENCES user_table(userid),
+    questionid int REFERENCES question(questionid),
     title char(50) NOT NULL,
     body char varying(100),
-    comment char varying(100),
-    FOREIGN KEY (userid) REFERENCES user_table(userid),
-    FOREIGN KEY (questionid) REFERENCES question(questionid)
-    )"""
+    comment char varying(100)
+    );"""
     query = [users, meetups, question, reserve, comment]
     return query
 


### PR DESCRIPTION
### What does this PR do?
Adds tests for delete meetup endpoint.
Modifies the tables with a meetup id to include 'on delete cascade' constraint.

### Description of the task to be completed.
Implementation of tests for the delete meetup endpoint.
Modification of tables with a meetup id to include 'on delete cascade' constraint in order to allow the delete request to delete even in the tables where the specific meetup record has been referenced.

### How can this be manually tested?
Open the terminal.
Enter git clone https://github.com/wathigo/Questioner.git
Navigate to the cloned repository.
Enter flask run.
Test the endpoints using postman.

### Relevant PT stories
#163508716

### Screenshots
![screenshot from 2019-01-28 02-25-42](https://user-images.githubusercontent.com/44072711/51820770-d977d180-22a4-11e9-8fb2-d14a51d009c1.png)

